### PR TITLE
Fixed unreachable nodes in generated CFGs not being removed

### DIFF
--- a/src/Symbooglix/Analysis/LoopInfo.cs
+++ b/src/Symbooglix/Analysis/LoopInfo.cs
@@ -54,6 +54,7 @@ namespace Symbooglix
         {
             // Compute the basic blocks that escape loops
             foreach (var impl in Prog.Implementations) {
+                impl.PruneUnreachableBlocks();
                 var CFG = Program.GraphFromImpl(impl);
                 CFG.ComputeLoops();
                 foreach (var Header in CFG.Headers) {

--- a/src/Symbooglix/Executor/StateSchedulers/LoopEscapingScheduler.cs
+++ b/src/Symbooglix/Executor/StateSchedulers/LoopEscapingScheduler.cs
@@ -110,6 +110,7 @@ namespace Symbooglix
             // Compute the basic blocks that escape loops
             foreach(var impl in executor.TheProgram.Implementations)
             {
+                impl.PruneUnreachableBlocks();
                 var CFG = Program.GraphFromImpl(impl);
                 CFG.ComputeLoops();
                 foreach (var Header in CFG.Headers)


### PR DESCRIPTION
Unreachable nodes being present in generated CFGs was resulting in an
ArgumentNullException being thrown in Boogie code.