### PR TITLE
Fix #32: Add pass to prune unreachable blocks 

### DIFF
--- a/src/Symbooglix/Executor/Executor.cs
+++ b/src/Symbooglix/Executor/Executor.cs
@@ -353,6 +353,9 @@ namespace Symbooglix
             InternalPreparationPassManager.Add(FRF);
             InternalPreparationPassManager.Add(new Transform.FunctionInliningPass());
 
+            //This is a workaround to the issue described at https://github.com/boogie-org/boogie/issues/92.
+            InternalPreparationPassManager.Add(new Transform.PruneUnreachableBlocksPass());
+
             if (UseGlobalDDE)
                 InternalPreparationPassManager.Add(new Transform.GlobalDeadDeclEliminationPass());
 

--- a/src/Symbooglix/Symbooglix.csproj
+++ b/src/Symbooglix/Symbooglix.csproj
@@ -35,6 +35,7 @@
     <Compile Include="Expr\Traverser.cs" />
     <Compile Include="Expr\SMTLIBQueryPrinter.cs" />
     <Compile Include="Expr\NonSymbolicDuplicator.cs" />
+    <Compile Include="Transform\PruneUnreachableBlocksPass.cs" />
     <Compile Include="Util\ExceptionThrowingTextWriterTraceListener.cs" />
     <Compile Include="Solver\DummySolver.cs" />
     <Compile Include="Solver\ISolver.cs" />

--- a/src/Symbooglix/Transform/PruneUnreachableBlocksPass.cs
+++ b/src/Symbooglix/Transform/PruneUnreachableBlocksPass.cs
@@ -1,0 +1,50 @@
+﻿//------------------------------------------------------------------------------
+//                                  Symbooglix
+//
+//
+// Copyright 2018 Liam Machado
+//
+// This file is licensed under the 2-Clause BSD license.
+// See LICENSE for details.
+//------------------------------------------------------------------------------
+using System;
+using Microsoft.Boogie;
+using System.Collections.Generic;
+
+namespace Symbooglix
+{
+    namespace Transform
+    {
+        public class PruneUnreachableBlocksPass : IPass
+        {
+            public PruneUnreachableBlocksPass()
+            {
+            }
+
+            public string GetName()
+            {
+                return "Prune Unreachable Blocks Pass";
+            }
+
+            public void SetPassInfo(ref PassInfo passInfo)
+            {
+                return;
+            }
+
+            public bool RunOn(Microsoft.Boogie.Program prog, PassInfo passInfo)
+            {
+                foreach (var impl in prog.Implementations)
+                {
+                    impl.PruneUnreachableBlocks();
+                }
+                return true;
+            }
+
+            public void Reset()
+            {
+                // Nothing to do
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Unreachable nodes being present in generated CFGs was resulting in an
ArgumentNullException being thrown in Boogie code. This issue is described more in depth on this page:

https://github.com/boogie-org/boogie/issues/92